### PR TITLE
Rework code to replace the internal buffer with io::Write and escape more chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@
 [![Rust 1.32+](https://img.shields.io/badge/rust-1.32+-orange.svg)](https://www.rust-lang.org)
 ![](https://img.shields.io/badge/unsafe-forbidden-brightgreen.svg)
 
-A simple, streaming, partially-validating XML writer that writes XML data into an internal buffer.
+A simple, streaming, partially-validating XML writer that writes XML data to a
+std::io::Write implementation.
 
 ### Features
 
-- A simple, bare-minimum, panic-based API.
+- A simple, bare-minimum API that panics when writing invalid XML.
 - Non-allocating API. All methods are accepting either `fmt::Display` or `fmt::Arguments`.
 - Nodes auto-closing.
 
@@ -17,29 +18,35 @@ A simple, streaming, partially-validating XML writer that writes XML data into a
 
 ```rust
 use xmlwriter::*;
+use std::io;
 
-let opt = Options {
-    use_single_quote: true,
-    ..Options::default()
-};
+fn main() -> io::Result<()> {
+    let opt = Options {
+        use_single_quote: true,
+        ..Options::default()
+    };
 
-let mut w = XmlWriter::new(opt);
-w.start_element("svg");
-w.write_attribute("xmlns", "http://www.w3.org/2000/svg");
-w.write_attribute_fmt("viewBox", format_args!("{} {} {} {}", 0, 0, 128, 128));
-w.start_element("text");
-// We can write any object that implements `fmt::Display`.
-w.write_attribute("x", &10);
-w.write_attribute("y", &20);
-w.write_text_fmt(format_args!("length is {}", 5));
+    let mut w = XmlWriter::new(Vec::<u8>::new(), opt);
+    w.start_element("svg")?;
+    w.write_attribute("xmlns", "http://www.w3.org/2000/svg")?;
+    w.write_attribute_fmt("viewBox", format_args!("{} {} {} {}", 0, 0, 128, 128))?;
+    w.start_element("text")?;
+    // We can write any object that implements `fmt::Display`.
+    w.write_attribute("x", &10)?;
+    w.write_attribute("y", &20)?;
+    w.write_text_fmt(format_args!("length is {}", 5))?;
 
-assert_eq!(w.end_document(),
+    assert_eq!(std::str::from_utf8(w.end_document()?.as_slice())
+        .expect("xmlwriter always writes valid UTF-8"),
 "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'>
     <text x='10' y='20'>
         length is 5
     </text>
 </svg>
-");
+"
+    );
+    Ok(())
+}
 ```
 
 ### License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,53 +1,55 @@
 /*!
-A simple, streaming, partially-validating XML writer that writes XML data into an internal buffer.
+A simple, streaming, partially-validating XML writer that writes XML data to a
+std::io::Write implementation.
 
-## Features
+### Features
 
-- A simple, bare-minimum, panic-based API.
+- A simple, bare-minimum API that panics when writing invalid XML.
 - Non-allocating API. All methods are accepting either `fmt::Display` or `fmt::Arguments`.
 - Nodes auto-closing.
 
-## Example
+### Example
 
 ```rust
 use xmlwriter::*;
+use std::io;
 
-let opt = Options {
-    use_single_quote: true,
-    ..Options::default()
-};
+fn main() -> io::Result<()> {
+    let opt = Options {
+        use_single_quote: true,
+        ..Options::default()
+    };
 
-let mut w = XmlWriter::new(opt);
-w.start_element("svg");
-w.write_attribute("xmlns", "http://www.w3.org/2000/svg");
-w.write_attribute_fmt("viewBox", format_args!("{} {} {} {}", 0, 0, 128, 128));
-w.start_element("text");
-// We can write any object that implements `fmt::Display`.
-w.write_attribute("x", &10);
-w.write_attribute("y", &20);
-w.write_text_fmt(format_args!("length is {}", 5));
+    let mut w = XmlWriter::new(Vec::<u8>::new(), opt);
+    w.start_element("svg")?;
+    w.write_attribute("xmlns", "http://www.w3.org/2000/svg")?;
+    w.write_attribute_fmt("viewBox", format_args!("{} {} {} {}", 0, 0, 128, 128))?;
+    w.start_element("text")?;
+    // We can write any object that implements `fmt::Display`.
+    w.write_attribute("x", &10)?;
+    w.write_attribute("y", &20)?;
+    w.write_text_fmt(format_args!("length is {}", 5))?;
 
-assert_eq!(w.end_document(),
+    assert_eq!(std::str::from_utf8(w.end_document()?.as_slice())
+        .expect("xmlwriter always writes valid UTF-8"),
 "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'>
     <text x='10' y='20'>
         length is 5
     </text>
 </svg>
-");
+"
+    );
+    Ok(())
+}
 ```
 */
-
-#![doc(html_root_url = "https://docs.rs/xmlwriter/0.1.0")]
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 #![warn(missing_copy_implementations)]
 
-
-use std::fmt::{self, Display};
-use std::io::Write;
-use std::ops::Range;
-
+use std::fmt::{self, Display, Write as FmtWrite};
+use std::io::{self, Write};
 
 /// An XML node indention.
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -143,7 +145,6 @@ impl Default for Options {
     }
 }
 
-
 #[derive(Clone, Copy, PartialEq, Debug)]
 enum State {
     Empty,
@@ -151,43 +152,129 @@ enum State {
     Attributes,
 }
 
-struct DepthData {
-    range: Range<usize>,
+struct DepthData<'a> {
+    element_name: Option<&'a str>,
     has_children: bool,
 }
 
+// This wrapper writer is so that we can make sure formatted strings are properly escaped too,
+// as we don't have access to the formatting stuff without a fmt::Write implementation, so
+// we provide it by wrapping the writer given to us while escaping appropriately any string to
+// be written, depending on the type of node we're writing.
+struct FmtWriter<W: Write> {
+    writer: W,
+    error_kind: Option<io::ErrorKind>,
+    // Set to None once the text is written, as a way to make sure the code
+    // sets the proper escaping type before using the fmt_writer.write_str().
+    escape: Option<Escape>,
+    // Same as for Options, but kept available for write_escaped()
+    use_single_quote: bool,
+}
+
+impl<W: Write> FmtWriter<W> {
+    fn take_err(&mut self) -> io::Error {
+        let error_kind = self
+            .error_kind
+            .expect("there must have been an error before calling take_err()!");
+        // This avoids forgetting to set it to the appropriate value when calling write_fmt().
+        // We can't do it in FmtWriter's write_str(), since with a real format string the method
+        // will be called several times so it'll fail in the expect() below as we'll have set
+        // self.escape back to None.
+        self.escape = None;
+        // Make sure we can detect if take_err() is called without having an error that happened beforehand
+        self.error_kind = None;
+
+        // There's just no way of properly copying the io::Error (no Copy or Clone available), so
+        // we have no choice to create a new one, which likely loses the backtrace up to this point.
+        io::Error::from(error_kind)
+    }
+
+    fn write_escaped(&mut self, s: &str, escape_quotes: bool) -> io::Result<()> {
+        let mut part_start_pos = 0;
+        for (byte_pos, byte) in s.bytes().enumerate() {
+            let escaped_char: Option<&[u8]> = match byte {
+                b'&' => Some(b"&amp;"),
+                b'>' => Some(b"&gt;"),
+                b'<' => Some(b"&lt;"),
+                b'"' if escape_quotes && !self.use_single_quote => Some(b"&quot;"),
+                b'\'' if escape_quotes && self.use_single_quote => Some(b"&apos;"),
+                _ => None,
+            };
+            if let Some(escaped_char) = escaped_char {
+                // We have a character to escape, so write the previous part and the escaped character
+                self.writer
+                    .write_all(&s[part_start_pos..byte_pos].as_bytes())?;
+                self.writer.write_all(escaped_char)?;
+                // +1 skips the escaped character from part, for afterwards
+                part_start_pos = byte_pos + 1;
+            }
+            // There's nothing to be done if the character doesn't need to be escaped, as we'll either
+            // wait until we get an escapable character, or wait until the end of the string where we'll
+            // just write out the rest of the string.
+        }
+        // Write the rest of the string which needs no escaping
+        self.writer.write_all(&s[part_start_pos..].as_bytes())
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+enum Escape {
+    Comment,
+    AttributeValue,
+    Text,
+}
+
+impl<W: Write> fmt::Write for FmtWriter<W> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let error = match self
+            .escape
+            .expect("You must have set self.escape to Some(…) before using the formatter!")
+        {
+            Escape::AttributeValue => self.write_escaped(s, true),
+            Escape::Text => self.write_escaped(s, false),
+            // We don't bother escaping double hyphen (--) in comment as it's
+            // unlikely to ever happen, and even libxml2 does not do it.
+            Escape::Comment => self.writer.write_all(s.as_bytes()),
+        };
+        if error.is_err() {
+            self.error_kind = Some(error.as_ref().unwrap_err().kind());
+            Err(fmt::Error)
+        } else {
+            Ok(())
+        }
+    }
+}
 
 /// An XML writer.
-pub struct XmlWriter {
-    buf: Vec<u8>,
+pub struct XmlWriter<'a, W: Write> {
+    // When you control what you're writing enough that you know the bytes are already escaped or
+    // don't need escaping at all, then use fmt_writer.writer.write_all()?; directly. Otherwise,
+    // set fmt_writer.escape to the appropriate escaping type and use fmt_writer.write_fmt()?; or
+    // fmt_writer.write_str()?; if you are only printing a string directly without formatting, but
+    // still want escaping to be done.
+    fmt_writer: FmtWriter<W>,
     state: State,
     preserve_whitespaces: bool,
-    depth_stack: Vec<DepthData>,
+    depth_stack: Vec<DepthData<'a>>,
     opt: Options,
 }
 
-impl XmlWriter {
+impl<'a, W: Write> XmlWriter<'a, W> {
+    /// Creates a new `XmlWriter`, writing data in the writer.
     #[inline]
-    fn from_vec(buf: Vec<u8>, opt: Options) -> Self {
+    pub fn new(writer: W, opt: Options) -> Self {
         XmlWriter {
-            buf,
+            fmt_writer: FmtWriter {
+                writer,
+                error_kind: None,
+                escape: None,
+                use_single_quote: opt.use_single_quote,
+            },
             state: State::Empty,
             preserve_whitespaces: false,
             depth_stack: Vec::new(),
             opt,
         }
-    }
-
-    /// Creates a new `XmlWriter`.
-    #[inline]
-    pub fn new(opt: Options) -> Self {
-        Self::from_vec(Vec::new(), opt)
-    }
-
-    /// Creates a new `XmlWriter` with a specified capacity.
-    #[inline]
-    pub fn with_capacity(capacity: usize, opt: Options) -> Self {
-        Self::from_vec(Vec::with_capacity(capacity), opt)
     }
 
     /// Writes an XML declaration.
@@ -198,7 +285,7 @@ impl XmlWriter {
     ///
     /// - When called twice.
     #[inline(never)]
-    pub fn write_declaration(&mut self) {
+    pub fn write_declaration(&mut self) -> io::Result<()> {
         if self.state != State::Empty {
             panic!("declaration was already written");
         }
@@ -207,80 +294,92 @@ impl XmlWriter {
         self.state = State::Attributes;
 
         // <?xml version='1.0' encoding='UTF-8' standalone='yes'?>
-        self.push_str("<?xml");
-        self.write_attribute("version", "1.0");
-        self.write_attribute("encoding", "UTF-8");
-        self.write_attribute("standalone", "no");
-        self.push_str("?>");
+        self.fmt_writer.writer.write_all(b"<?xml")?;
+        // We don't use write_all() directly so that we get quoting handling for free.
+        // However we can use the "raw" method here as we perfectly know there's no
+        // escaping needed, albeit the performance impact would be almost inexistent if
+        // we did use the regular method.
+        self.write_attribute_raw("version", |w| w.write_all(b"1.0"))?;
+        self.write_attribute_raw("encoding", |w| w.write_all(b"UTF-8"))?;
+        self.write_attribute_raw("standalone", |w| w.write_all(b"no"))?;
+        self.fmt_writer.writer.write_all(b"?>")?;
 
         self.state = State::Document;
+
+        Ok(())
     }
 
     /// Writes a comment string.
-    pub fn write_comment(&mut self, text: &str) {
-        self.write_comment_fmt(format_args!("{}", text));
+    pub fn write_comment(&mut self, text: &str) -> io::Result<()> {
+        self.write_comment_fmt(format_args!("{}", text))
     }
 
-    /// Writes a formatted comment.
+    /// Writes a formatted comment. Forbidden double hyphens will be escaped.
     #[inline(never)]
-    pub fn write_comment_fmt(&mut self, fmt: fmt::Arguments) {
+    pub fn write_comment_fmt(&mut self, fmt: fmt::Arguments) -> io::Result<()> {
         if self.state == State::Attributes {
-            self.write_open_element();
+            self.write_open_element()?;
         }
 
         if self.state != State::Empty {
-            self.write_new_line();
+            self.write_new_line()?;
         }
 
-        self.write_node_indent();
+        self.write_node_indent()?;
 
         // <!--text-->
-        self.push_str("<!--");
-        self.buf.write_fmt(fmt).unwrap(); // TODO: check content
-        self.push_str("-->");
+        self.fmt_writer.writer.write_all(b"<!--")?;
+        self.fmt_writer.escape = Some(Escape::Comment);
+        self.fmt_writer
+            .write_fmt(fmt)
+            .map_err(|_| self.fmt_writer.take_err())?;
+        self.fmt_writer.writer.write_all(b"-->")?;
 
         if self.state == State::Attributes {
             self.depth_stack.push(DepthData {
-                range: 0..0,
+                element_name: None,
                 has_children: false,
             });
         }
 
         self.state = State::Document;
+
+        Ok(())
     }
 
     /// Starts writing a new element.
     ///
     /// This method writes only the `<tag-name` part.
     #[inline(never)]
-    pub fn start_element(&mut self, name: &str) {
+    pub fn start_element(&mut self, name: &'a str) -> io::Result<()> {
         if self.state == State::Attributes {
-            self.write_open_element();
+            self.write_open_element()?;
         }
 
         if self.state != State::Empty {
-            self.write_new_line();
+            self.write_new_line()?;
         }
 
         if !self.preserve_whitespaces {
-            self.write_node_indent();
+            self.write_node_indent()?;
         }
 
-        self.push_byte(b'<');
-        let start = self.buf.len();
-        self.push_str(name);
+        self.fmt_writer.writer.write_all(b"<")?;
+        self.fmt_writer.writer.write_all(name.as_bytes())?;
 
         self.depth_stack.push(DepthData {
-            range: start..self.buf.len(),
+            element_name: Some(name),
             has_children: false,
         });
 
         self.state = State::Attributes;
+
+        Ok(())
     }
 
     /// Writes an attribute.
     ///
-    /// Quotes in the value will be escaped.
+    /// Any occurrence of `&<>"'` in the value will be escaped.
     ///
     /// # Panics
     ///
@@ -291,20 +390,31 @@ impl XmlWriter {
     ///
     /// ```
     /// use xmlwriter::*;
+    /// use std::io;
     ///
-    /// let mut w = XmlWriter::new(Options::default());
-    /// w.start_element("svg");
-    /// w.write_attribute("x", "5");
-    /// w.write_attribute("y", &5);
-    /// assert_eq!(w.end_document(), "<svg x=\"5\" y=\"5\"/>\n");
+    /// fn main() -> io::Result<()> {
+    ///     let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    ///     w.start_element("svg")?;
+    ///     w.write_attribute("x", "5")?;
+    ///     w.write_attribute("y", &5)?;
+    ///     assert_eq!(std::str::from_utf8(w.end_document()?.as_slice())
+    ///         .expect("xmlwriter should always produce valid UTF-8"),
+    ///         "<svg x=\"5\" y=\"5\"/>\n",
+    ///     );
+    ///     Ok(())
+    /// }
     /// ```
-    pub fn write_attribute<V: Display + ?Sized>(&mut self, name: &str, value: &V) {
-        self.write_attribute_fmt(name, format_args!("{}", value));
+    pub fn write_attribute<V: Display + ?Sized>(
+        &mut self,
+        name: &str,
+        value: &V,
+    ) -> io::Result<()> {
+        self.write_attribute_fmt(name, format_args!("{}", value))
     }
 
     /// Writes a formatted attribute value.
     ///
-    /// Quotes in the value will be escaped.
+    /// Any occurrence of `&<>"'` in the value will be escaped.
     ///
     /// # Panics
     ///
@@ -315,31 +425,40 @@ impl XmlWriter {
     ///
     /// ```
     /// use xmlwriter::*;
+    /// use std::io;
     ///
-    /// let mut w = XmlWriter::new(Options::default());
-    /// w.start_element("rect");
-    /// w.write_attribute_fmt("fill", format_args!("url(#{})", "gradient"));
-    /// assert_eq!(w.end_document(), "<rect fill=\"url(#gradient)\"/>\n");
+    /// fn main() -> io::Result<()> {
+    ///     let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    ///     w.start_element("rect")?;
+    ///     w.write_attribute_fmt("fill", format_args!("url(#{})", "gradient"))?;
+    ///     assert_eq!(std::str::from_utf8(w.end_document()?.as_slice())
+    ///         .expect("xmlwriter should always produce valid UTF-8"),
+    ///         "<rect fill=\"url(#gradient)\"/>\n"
+    ///     );
+    ///     Ok(())
+    /// }
     /// ```
     #[inline(never)]
-    pub fn write_attribute_fmt(&mut self, name: &str, fmt: fmt::Arguments) {
+    pub fn write_attribute_fmt(&mut self, name: &str, fmt: fmt::Arguments) -> io::Result<()> {
         if self.state != State::Attributes {
             panic!("must be called after start_element()");
         }
 
-        self.write_attribute_prefix(name);
-        let start = self.buf.len();
-        self.buf.write_fmt(fmt).unwrap();
-        self.escape_attribute_value(start);
-        self.write_quote();
+        self.write_attribute_prefix(name)?;
+        self.fmt_writer.escape = Some(Escape::AttributeValue);
+        self.fmt_writer
+            .write_fmt(fmt)
+            .map_err(|_| self.fmt_writer.take_err())?;
+        self.write_quote()
     }
 
-    /// Writes a raw attribute value.
+    /// Writes a raw attribute value, without performing escaping.
     ///
-    /// Closure provides a mutable reference to an internal buffer.
+    /// Closure provides a mutable reference to the writer.
     ///
     /// **Warning:** this method is an escape hatch for cases when you need to write
-    /// a lot of data very fast.
+    /// a lot of data very fast, and as such does no validity checks whatsoever on the
+    /// written value.
     ///
     /// # Panics
     ///
@@ -350,60 +469,51 @@ impl XmlWriter {
     ///
     /// ```
     /// use xmlwriter::*;
+    /// use std::io::{self, Write};
     ///
-    /// let mut w = XmlWriter::new(Options::default());
-    /// w.start_element("path");
-    /// w.write_attribute_raw("d", |buf| buf.extend_from_slice(b"M 10 20 L 30 40"));
-    /// assert_eq!(w.end_document(), "<path d=\"M 10 20 L 30 40\"/>\n");
+    /// fn main() -> io::Result<()> {
+    ///     let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    ///     w.start_element("path")?;
+    ///     w.write_attribute_raw("d", |writer| writer.write_all(b"M 10 20 L 30 40"))?;
+    ///     assert_eq!(std::str::from_utf8(w.end_document()?.as_slice())
+    ///         .expect("xmlwriter should always produce valid UTF-8"),
+    ///         "<path d=\"M 10 20 L 30 40\"/>\n"
+    ///     );
+    ///     Ok(())
+    /// }
     /// ```
     #[inline(never)]
-    pub fn write_attribute_raw<F>(&mut self, name: &str, f: F)
-        where F: FnOnce(&mut Vec<u8>)
+    pub fn write_attribute_raw<F>(&mut self, name: &str, f: F) -> io::Result<()>
+    where
+        F: FnOnce(&mut W) -> io::Result<()>,
     {
         if self.state != State::Attributes {
             panic!("must be called after start_element()");
         }
 
-        self.write_attribute_prefix(name);
-        let start = self.buf.len();
-        f(&mut self.buf);
-        self.escape_attribute_value(start);
-        self.write_quote();
+        self.write_attribute_prefix(name)?;
+        f(&mut self.fmt_writer.writer)?;
+        self.write_quote()
     }
 
     #[inline(never)]
-    fn write_attribute_prefix(&mut self, name: &str) {
+    fn write_attribute_prefix(&mut self, name: &str) -> io::Result<()> {
         if self.opt.attributes_indent == Indent::None {
-            self.push_byte(b' ');
+            self.fmt_writer.writer.write_all(b" ")?;
         } else {
-            self.push_byte(b'\n');
+            self.fmt_writer.writer.write_all(b"\n")?;
 
             let depth = self.depth_stack.len();
             if depth > 0 {
-                self.write_indent(depth - 1, self.opt.indent);
+                self.write_indent(depth - 1, self.opt.indent)?;
             }
 
-            self.write_indent(1, self.opt.attributes_indent);
+            self.write_indent(1, self.opt.attributes_indent)?;
         }
 
-        self.push_str(name);
-        self.push_byte(b'=');
-        self.write_quote();
-    }
-
-    /// Escapes the attribute value string.
-    ///
-    /// - " -> &quot;
-    /// - ' -> &apos;
-    #[inline(never)]
-    fn escape_attribute_value(&mut self, mut start: usize) {
-        let quote = if self.opt.use_single_quote { b'\'' } else { b'"' };
-        while let Some(idx) = self.buf[start..].iter().position(|c| *c == quote) {
-            let i = start + idx;
-            let s = if self.opt.use_single_quote { b"&apos;" } else { b"&quot;" };
-            self.buf.splice(i..i+1, s.iter().cloned());
-            start = i + 6;
-        }
+        self.fmt_writer.writer.write_all(name.as_bytes())?;
+        self.fmt_writer.writer.write_all(b"=")?;
+        self.write_quote()
     }
 
     /// Sets the preserve whitespaces flag.
@@ -417,25 +527,31 @@ impl XmlWriter {
     ///
     /// ```
     /// use xmlwriter::*;
+    /// use std::io;
     ///
-    /// let mut w = XmlWriter::new(Options::default());
-    /// w.start_element("html");
-    /// w.start_element("p");
-    /// w.write_text("text");
-    /// w.end_element();
-    /// w.start_element("p");
-    /// w.set_preserve_whitespaces(true);
-    /// w.write_text("text");
-    /// w.end_element();
-    /// w.set_preserve_whitespaces(false);
-    /// assert_eq!(w.end_document(),
+    /// fn main() -> io::Result<()> {
+    ///     let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    ///     w.start_element("html")?;
+    ///     w.start_element("p")?;
+    ///     w.write_text("text")?;
+    ///     w.end_element()?;
+    ///     w.start_element("p")?;
+    ///     w.set_preserve_whitespaces(true);
+    ///     w.write_text("text")?;
+    ///     w.end_element()?;
+    ///     w.set_preserve_whitespaces(false);
+    ///     assert_eq!(std::str::from_utf8(w.end_document()?.as_slice())
+    ///         .expect("xmlwriter should produce valid UTF-8"),
     /// "<html>
     ///     <p>
     ///         text
     ///     </p>
     ///     <p>text</p>
     /// </html>
-    /// ");
+    /// "
+    ///     );
+    ///     Ok(())
+    /// }
     /// ```
     pub fn set_preserve_whitespaces(&mut self, preserve: bool) {
         self.preserve_whitespaces = preserve;
@@ -444,147 +560,149 @@ impl XmlWriter {
     /// Writes a text node.
     ///
     /// See `write_text_fmt()` for details.
-    pub fn write_text(&mut self, text: &str) {
-        self.write_text_fmt(format_args!("{}", text));
+    pub fn write_text<T: Display + ?Sized>(&mut self, text: &T) -> io::Result<()> {
+        self.write_text_fmt(format_args!("{}", text))
     }
 
     /// Writes a formatted text node.
     ///
-    /// `<` will be escaped.
+    /// `><&` will be escaped.
     ///
     /// # Panics
     ///
     /// - When called not after `start_element()`.
     #[inline(never)]
-    pub fn write_text_fmt(&mut self, fmt: fmt::Arguments) {
+    pub fn write_text_fmt(&mut self, fmt: fmt::Arguments) -> io::Result<()> {
         if self.state == State::Empty || self.depth_stack.is_empty() {
             panic!("must be called after start_element()");
         }
 
         if self.state == State::Attributes {
-            self.write_open_element();
+            self.write_open_element()?;
         }
 
         if self.state != State::Empty {
-            self.write_new_line();
+            self.write_new_line()?;
         }
 
-        self.write_node_indent();
+        self.write_node_indent()?;
 
-        let start = self.buf.len();
-        self.buf.write_fmt(fmt).unwrap();
-        self.escape_text(start);
+        self.fmt_writer.escape = Some(Escape::Text);
+        self.fmt_writer
+            .write_fmt(fmt)
+            .map_err(|_| self.fmt_writer.take_err())?;
 
         if self.state == State::Attributes {
             self.depth_stack.push(DepthData {
-                range: 0..0,
+                element_name: None,
                 has_children: false,
             });
         }
 
         self.state = State::Document;
-    }
 
-    fn escape_text(&mut self, mut start: usize) {
-        while let Some(idx) = self.buf[start..].iter().position(|c| *c == b'<') {
-            let i = start + idx;
-            self.buf.splice(i..i+1, b"&lt;".iter().cloned());
-            start = i + 4;
-        }
+        Ok(())
     }
 
     /// Closes an open element.
     #[inline(never)]
-    pub fn end_element(&mut self) {
+    pub fn end_element(&mut self) -> io::Result<()> {
         if let Some(depth) = self.depth_stack.pop() {
             if depth.has_children {
                 if !self.preserve_whitespaces {
-                    self.write_new_line();
-                    self.write_node_indent();
+                    self.write_new_line()?;
+                    self.write_node_indent()?;
                 }
 
-                self.push_str("</");
+                self.fmt_writer.writer.write_all(b"</")?;
 
-                for i in depth.range {
-                    self.push_byte(self.buf[i]);
-                }
+                // Write the previous opening element name as closing element now.
+                self.fmt_writer.writer.write_all(
+                    depth
+                        .element_name
+                        .expect("did not have opening element name when closing element")
+                        .as_bytes(),
+                )?;
 
-                self.push_byte(b'>');
+                self.fmt_writer.writer.write_all(b">")?;
             } else {
-                self.push_str("/>");
+                self.fmt_writer.writer.write_all(b"/>")?;
             }
         }
 
         self.state = State::Document;
+
+        Ok(())
     }
 
-    /// Closes all open elements and returns an internal XML buffer.
+    /// Closes all open elements and returns back the writer.
     ///
     /// # Example
     ///
     /// ```
     /// use xmlwriter::*;
+    /// use std::io;
     ///
-    /// let mut w = XmlWriter::new(Options::default());
-    /// w.start_element("svg");
-    /// w.start_element("g");
-    /// w.start_element("rect");
-    /// assert_eq!(w.end_document(),
+    /// fn main() -> io::Result<()> {
+    ///     let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    ///     w.start_element("svg")?;
+    ///     w.start_element("g")?;
+    ///     w.start_element("rect")?;
+    ///     assert_eq!(std::str::from_utf8(w.end_document()?.as_slice())
+    ///         .expect("xmlwriter should always produce valid UTF-8"),
     /// "<svg>
     ///     <g>
     ///         <rect/>
     ///     </g>
     /// </svg>
-    /// ");
+    /// "
+    ///     );
+    ///     Ok(())
+    /// }
     /// ```
-    pub fn end_document(mut self) -> String {
+    pub fn end_document(mut self) -> io::Result<W> {
         while !self.depth_stack.is_empty() {
-            self.end_element();
+            self.end_element()?;
         }
 
-        self.write_new_line();
+        self.write_new_line()?;
 
-        // The only way it can fail is if an invalid data
-        // was written via `write_attribute_raw()`.
-        String::from_utf8(self.buf).unwrap()
-    }
-
-    #[inline]
-    fn push_byte(&mut self, c: u8) {
-        self.buf.push(c);
-    }
-
-    #[inline]
-    fn push_str(&mut self, text: &str) {
-        self.buf.extend_from_slice(text.as_bytes());
+        Ok(self.fmt_writer.writer)
     }
 
     #[inline]
     fn get_quote_char(&self) -> u8 {
-        if self.opt.use_single_quote { b'\'' } else { b'"' }
-    }
-
-    #[inline]
-    fn write_quote(&mut self) {
-        self.push_byte(self.get_quote_char());
-    }
-
-    fn write_open_element(&mut self) {
-        if let Some(depth) = self.depth_stack.last_mut() {
-            depth.has_children = true;
-            self.push_byte(b'>');
-
-            self.state = State::Document;
+        if self.opt.use_single_quote {
+            b'\''
+        } else {
+            b'"'
         }
     }
 
-    fn write_node_indent(&mut self) {
-        self.write_indent(self.depth_stack.len(), self.opt.indent);
+    // Writes quote unescaped, so only use when appropriate.
+    #[inline]
+    fn write_quote(&mut self) -> io::Result<()> {
+        self.fmt_writer.writer.write_all(&[self.get_quote_char()])
     }
 
-    fn write_indent(&mut self, depth: usize, indent: Indent) {
+    // Writes the end of the current opening element, so `>`.
+    fn write_open_element(&mut self) -> io::Result<()> {
+        if let Some(depth) = self.depth_stack.last_mut() {
+            depth.has_children = true;
+            self.fmt_writer.writer.write_all(b">")?;
+
+            self.state = State::Document;
+        }
+        Ok(())
+    }
+
+    fn write_node_indent(&mut self) -> io::Result<()> {
+        self.write_indent(self.depth_stack.len(), self.opt.indent)
+    }
+
+    fn write_indent(&mut self, depth: usize, indent: Indent) -> io::Result<()> {
         if indent == Indent::None || self.preserve_whitespaces {
-            return;
+            return Ok(());
         }
 
         for _ in 0..depth {
@@ -592,17 +710,19 @@ impl XmlWriter {
                 Indent::None => {}
                 Indent::Spaces(n) => {
                     for _ in 0..n {
-                        self.push_byte(b' ');
+                        self.fmt_writer.writer.write_all(b" ")?;
                     }
                 }
-                Indent::Tabs => self.push_byte(b'\t'),
+                Indent::Tabs => self.fmt_writer.writer.write_all(b"\t")?,
             }
         }
+        Ok(())
     }
 
-    fn write_new_line(&mut self) {
+    fn write_new_line(&mut self) -> io::Result<()> {
         if self.opt.indent != Indent::None && !self.preserve_whitespaces {
-            self.push_byte(b'\n');
+            self.fmt_writer.writer.write_all(b"\n")?;
         }
+        Ok(())
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,64 +1,75 @@
-use std::str;
-use xmlwriter::{XmlWriter, Options};
-
-#[derive(Clone, Copy, PartialEq)]
-struct TStr<'a>(pub &'a str);
+use std::{
+    io::{self, Write},
+    str::from_utf8,
+};
+use xmlwriter::{Options, XmlWriter};
 
 macro_rules! text_eq {
-    ($result:expr, $expected:expr) => { assert_eq!($result, $expected) };
-}
-
-
-#[test]
-fn write_element_01() {
-    let mut w = XmlWriter::new(Options::default());
-    w.start_element("svg");
-    w.end_element();
-    text_eq!(w.end_document(), "<svg/>\n");
+    ($result:expr, $expected:expr) => {
+        assert_eq!(
+            from_utf8($result.as_slice()).expect("XmlWriter should produce valid UTF8"),
+            $expected,
+        )
+    };
 }
 
 #[test]
-fn write_element_02() {
-    let mut w = XmlWriter::new(Options::default());
-    w.start_element("svg");
-    w.start_element("rect");
-    w.end_element();
-    w.end_element();
-    text_eq!(w.end_document(),
-"<svg>
+fn write_element_01() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("svg")?;
+    w.end_element()?;
+    text_eq!(w.end_document()?, "<svg/>\n");
+    Ok(())
+}
+
+#[test]
+fn write_element_02() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("svg")?;
+    w.start_element("rect")?;
+    w.end_element()?;
+    w.end_element()?;
+    text_eq!(
+        w.end_document()?,
+        r#"<svg>
     <rect/>
 </svg>
-");
+"#
+    );
+    Ok(())
 }
 
 #[test]
-fn write_element_03() {
-    let mut w = XmlWriter::new(Options::default());
-    w.start_element("svg");
-    w.end_element();
-    w.end_element(); // Should not panic.
-    text_eq!(w.end_document(), "<svg/>\n");
+fn write_element_03() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("svg")?;
+    w.end_element()?;
+    w.end_element()?; // Should not panic.
+    text_eq!(w.end_document()?, "<svg/>\n");
+    Ok(())
 }
 
 #[test]
-fn write_element_05() {
-    let mut w = XmlWriter::new(Options::default());
-    w.start_element("svg");
+fn write_element_05() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("svg")?;
     // end_document() will call `close_element` automatically.
-    text_eq!(w.end_document(), "<svg/>\n");
+    text_eq!(w.end_document()?, "<svg/>\n");
+    Ok(())
 }
 
 #[test]
-fn write_element_06() {
-    let mut w = XmlWriter::new(Options::default());
-    w.start_element("svg");
-    w.start_element("rect");
-    w.start_element("rect");
-    w.start_element("rect");
-    w.start_element("rect");
-    w.start_element("rect");
-    text_eq!(w.end_document(),
-"<svg>
+fn write_element_06() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("svg")?;
+    w.start_element("rect")?;
+    w.start_element("rect")?;
+    w.start_element("rect")?;
+    w.start_element("rect")?;
+    w.start_element("rect")?;
+    text_eq!(
+        w.end_document()?,
+        r#"<svg>
     <rect>
         <rect>
             <rect>
@@ -69,326 +80,420 @@ fn write_element_06() {
         </rect>
     </rect>
 </svg>
-");
+"#
+    );
+    Ok(())
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "must be called after start_element()")]
 fn write_attribute_01() {
-    let mut w = XmlWriter::new(Options::default());
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
     // must be used only after write_element
-    w.write_attribute("id", "q");
+    w.write_attribute("id", "q")
+        .expect("no IO error since we're supposed to panic first");
 }
 
 #[test]
-fn write_attribute_02() {
-    let mut w = XmlWriter::new(Options::default());
-    w.start_element("svg");
-    w.write_attribute("id", "q");
-    w.end_element();
-    text_eq!(w.end_document(), "<svg id=\"q\"/>\n");
+fn write_attribute_02() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("svg")?;
+    w.write_attribute("id", "q")?;
+    w.end_element()?;
+    text_eq!(w.end_document()?, "<svg id=\"q\"/>\n");
+    Ok(())
 }
 
 #[test]
-fn write_attribute_03() {
-    let mut w = XmlWriter::new(Options::default());
-    w.start_element("svg");
-    w.write_attribute("id", "\"");
-    w.end_element();
-    text_eq!(w.end_document(), "<svg id=\"&quot;\"/>\n");
+fn write_attribute_03() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("svg")?;
+    w.write_attribute("id", "\"")?;
+    w.end_element()?;
+    text_eq!(w.end_document()?, "<svg id=\"&quot;\"/>\n");
+    Ok(())
 }
 
 #[test]
-fn write_attribute_04() {
+fn write_attribute_04() -> io::Result<()> {
     let opt = Options {
         use_single_quote: true,
-        .. Options::default()
+        ..Options::default()
     };
 
-    let mut w = XmlWriter::new(opt);
-    w.start_element("svg");
-    w.write_attribute("id", "'");
-    w.end_element();
-    text_eq!(w.end_document(), "<svg id='&apos;'/>\n");
+    let mut w = XmlWriter::new(Vec::<u8>::new(), opt);
+    w.start_element("svg")?;
+    w.write_attribute("id", "'")?;
+    w.end_element()?;
+    text_eq!(w.end_document()?, "<svg id='&apos;'/>\n");
+    Ok(())
 }
 
 #[test]
-fn write_attribute_05() {
+fn write_attribute_05() -> io::Result<()> {
     let opt = Options {
         use_single_quote: true,
-        .. Options::default()
+        ..Options::default()
     };
 
-    let mut w = XmlWriter::new(opt);
-    w.start_element("svg");
-    w.write_attribute("id", "'''''");
-    w.end_element();
-    text_eq!(w.end_document(), "<svg id='&apos;&apos;&apos;&apos;&apos;'/>\n");
+    let mut w = XmlWriter::new(Vec::<u8>::new(), opt);
+    w.start_element("svg")?;
+    w.write_attribute("id", "'''\"'\"\"'")?;
+    w.end_element()?;
+    text_eq!(
+        w.end_document()?,
+        // We should only escape single quotes in attribute values when we're
+        // using single quotes around them too. In that case double quotes
+        // should not be escaped.
+        "<svg id='&apos;&apos;&apos;\"&apos;\"\"&apos;'/>\n"
+    );
+    Ok(())
+}
+
+// Same as write_attribute_05(), but to make sure single quotes aren't escaped
+// when using double quotes.
+#[test]
+fn write_attribute_06() -> io::Result<()> {
+    let opt = Options {
+        use_single_quote: false,
+        ..Options::default()
+    };
+
+    let mut w = XmlWriter::new(Vec::<u8>::new(), opt);
+    w.start_element("svg")?;
+    w.write_attribute("id", "'''\"'\"\"'")?;
+    w.end_element()?;
+    text_eq!(
+        w.end_document()?,
+        // We should only escape single quotes in attribute values when we're
+        // using single quotes around them too. In that case double quotes
+        // should not be escaped.
+        "<svg id=\"'''&quot;'&quot;&quot;'\"/>\n"
+    );
+    Ok(())
 }
 
 #[test]
-fn write_attribute_06() {
+fn write_attribute_07() -> io::Result<()> {
     let opt = Options {
         use_single_quote: true,
-        .. Options::default()
+        ..Options::default()
     };
 
-    let mut w = XmlWriter::new(opt);
-    w.start_element("svg");
-    w.write_attribute("id", "'text'");
-    w.end_element();
-    text_eq!(w.end_document(), "<svg id='&apos;text&apos;'/>\n");
+    let mut w = XmlWriter::new(Vec::<u8>::new(), opt);
+    w.start_element("svg")?;
+    w.write_attribute("id", "'text'")?;
+    w.end_element()?;
+    text_eq!(w.end_document()?, "<svg id='&apos;text&apos;'/>\n");
+    Ok(())
 }
 
 #[test]
-fn write_attribute_07() {
-    let mut w = XmlWriter::new(Options::default());
-    w.start_element("svg");
+fn write_attribute_08() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("svg")?;
     // TODO: looks we need specialization to remove &
-    w.write_attribute("x", &5);
-    w.end_element();
-    text_eq!(w.end_document(), "<svg x=\"5\"/>\n");
+    w.write_attribute("x", &5)?;
+    w.end_element()?;
+    text_eq!(w.end_document()?, "<svg x=\"5\"/>\n");
+    Ok(())
 }
 
 #[test]
-fn write_declaration_01() {
-    let mut w = XmlWriter::new(Options::default());
-    w.write_declaration();
-    text_eq!(w.end_document(),
-             "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n");
+fn write_attribute_09() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("foo")?;
+    w.write_attribute_raw("x", |writer| writer.write_all(br#"&&"''"<>><>"#))?;
+    w.end_element()?;
+    text_eq!(
+        w.end_document()?,
+        // It is invalid XML if you do that, but it'd be your fault then :)
+        r#"<foo x="&&"''"<>><>"/>
+"#
+    );
+    Ok(())
 }
 
 #[test]
-#[should_panic]
+fn write_declaration_01() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.write_declaration()?;
+    text_eq!(
+        w.end_document()?,
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
+    );
+    Ok(())
+}
+
+#[test]
+#[should_panic(expected = "declaration was already written")]
 fn write_declaration_02() {
-    let mut w = XmlWriter::new(Options::default());
-    w.write_declaration();
-    w.write_declaration();  // declaration must be written once
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.write_declaration()
+        .expect("we should only be panicking on the next line!");
+    w.write_declaration()
+        .expect("we'll panic before even returning a Result"); // declaration must be written once
 }
 
 #[test]
-#[should_panic]
+// declaration was already written
+#[should_panic(expected = "declaration was already written")]
 fn write_declaration_03() {
-    let mut w = XmlWriter::new(Options::default());
-    w.write_comment("test");
-    w.write_declaration(); // declaration must be written first
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.write_comment("test").expect("no error expected here!");
+    w.write_declaration()
+        .expect("we'll panic before even returning a Result"); // declaration must be written first
 }
 
 #[test]
-fn write_single_quote_01() {
+fn write_single_quote_01() -> io::Result<()> {
     let opt = Options {
         use_single_quote: true,
-        .. Options::default()
+        ..Options::default()
     };
 
-    let mut w = XmlWriter::new(opt);
-    w.write_declaration();
-    text_eq!(w.end_document(), "<?xml version='1.0' encoding='UTF-8' standalone='no'?>\n");
+    let mut w = XmlWriter::new(Vec::<u8>::new(), opt);
+    w.write_declaration()?;
+    text_eq!(
+        w.end_document()?,
+        "<?xml version='1.0' encoding='UTF-8' standalone='no'?>\n"
+    );
+    Ok(())
 }
 
 #[test]
-fn write_single_quote_02() {
+fn write_single_quote_02() -> io::Result<()> {
     let opt = Options {
         use_single_quote: true,
-        .. Options::default()
+        ..Options::default()
     };
 
-    let mut w = XmlWriter::new(opt);
-    w.start_element("p");
-    w.write_attribute("a", "b");
-    w.end_element();
-    text_eq!(w.end_document(), "<p a='b'/>\n");
+    let mut w = XmlWriter::new(Vec::<u8>::new(), opt);
+    w.start_element("p")?;
+    w.write_attribute("a", "b")?;
+    w.end_element()?;
+    text_eq!(w.end_document()?, "<p a='b'/>\n");
+    Ok(())
 }
 
 #[test]
-fn write_comment_01() {
-    let mut w = XmlWriter::new(Options::default());
-    w.write_comment("test");
-    w.start_element("svg");
-    text_eq!(w.end_document(),
-"<!--test-->
+fn write_comment_01() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.write_comment("test")?;
+    w.start_element("svg")?;
+    text_eq!(
+        w.end_document()?,
+        r#"<!--test-->
 <svg/>
-");
+"#
+    );
+    Ok(())
 }
 
 #[test]
-fn write_comment_02() {
-    let mut w = XmlWriter::new(Options::default());
-    w.start_element("svg");
-    w.write_comment("test");
-    text_eq!(w.end_document(),
-"<svg>
+fn write_comment_02() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("svg")?;
+    w.write_comment("test")?;
+    text_eq!(
+        w.end_document()?,
+        r#"<svg>
     <!--test-->
 </svg>
-");
+"#
+    );
+    Ok(())
 }
 
 #[test]
-fn write_comment_03() {
-    let mut w = XmlWriter::new(Options::default());
-    w.write_comment("test");
-    w.start_element("svg");
-    w.write_comment("test");
-    text_eq!(w.end_document(),
-"<!--test-->
+fn write_comment_03() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.write_comment("test")?;
+    w.start_element("svg")?;
+    w.write_comment("test")?;
+    text_eq!(
+        w.end_document()?,
+        r#"<!--test-->
 <svg>
     <!--test-->
 </svg>
-");
+"#
+    );
+    Ok(())
 }
 
 #[test]
-fn write_comment_04() {
-    let mut w = XmlWriter::new(Options::default());
-    w.write_comment("test");
-    w.start_element("svg");
-    w.start_element("rect");
-    w.write_comment("test");
-    text_eq!(w.end_document(),
-"<!--test-->
+fn write_comment_04() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.write_comment("test")?;
+    w.start_element("svg")?;
+    w.start_element("rect")?;
+    w.write_comment("test")?;
+    text_eq!(
+        w.end_document()?,
+        r#"<!--test-->
 <svg>
     <rect>
         <!--test-->
     </rect>
 </svg>
-");
+"#
+    );
+    Ok(())
 }
 
 #[test]
-fn write_comment_05() {
-    let mut w = XmlWriter::new(Options::default());
-    w.write_comment("test");
-    w.start_element("svg");
-    w.write_comment("test");
-    w.start_element("rect");
-    w.end_element();
-    text_eq!(w.end_document(),
-"<!--test-->
+fn write_comment_05() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.write_comment("test")?;
+    w.start_element("svg")?;
+    w.write_comment("test")?;
+    w.start_element("rect")?;
+    w.end_element()?;
+    text_eq!(
+        w.end_document()?,
+        r#"<!--test-->
 <svg>
     <!--test-->
     <rect/>
 </svg>
-");
+"#
+    );
+    Ok(())
 }
 
 #[test]
-fn write_comment_06() {
-    let mut w = XmlWriter::new(Options::default());
-    w.write_comment("test");
-    w.start_element("svg");
-    w.start_element("rect");
-    w.end_element();
-    w.write_comment("test");
-    text_eq!(w.end_document(),
-"<!--test-->
+fn write_comment_06() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.write_comment("test")?;
+    w.start_element("svg")?;
+    w.start_element("rect")?;
+    w.end_element()?;
+    w.write_comment("test")?;
+    text_eq!(
+        w.end_document()?,
+        r#"<!--test-->
 <svg>
     <rect/>
     <!--test-->
 </svg>
-");
+"#
+    );
+    Ok(())
 }
 
 #[test]
-fn write_comment_07() {
-    let mut w = XmlWriter::new(Options::default());
-    w.start_element("svg");
-    w.end_element();
-    w.write_comment("test");
-    text_eq!(w.end_document(),
-"<svg/>
+fn write_comment_07() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("svg")?;
+    w.end_element()?;
+    w.write_comment("test")?;
+    text_eq!(
+        w.end_document()?,
+        r#"<svg/>
 <!--test-->
-");
+"#
+    );
+    Ok(())
 }
 
 #[test]
-fn write_comment_08() {
-    let mut w = XmlWriter::new(Options::default());
-    w.write_comment("test");
-    w.write_comment("test");
-    w.write_comment("test");
-    text_eq!(w.end_document(),
-"<!--test-->
+fn write_comment_08() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.write_comment("test")?;
+    w.write_comment("test")?;
+    w.write_comment("test")?;
+    text_eq!(
+        w.end_document()?,
+        r#"<!--test-->
 <!--test-->
 <!--test-->
-");
+"#
+    );
+    Ok(())
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "must be called after start_element()")]
 fn write_text_01() {
-    let mut w = XmlWriter::new(Options::default());
-    w.write_text("text"); // Should be called after start_element()
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.write_text("text")
+        .expect("should panic before giving us a Result"); // Should be called after start_element()
 }
 
 #[test]
-#[should_panic]
-fn write_text_02() {
-    let mut w = XmlWriter::new(Options::default());
-    w.write_text("text"); // Should be called after start_element()
-}
-
-#[test]
-#[should_panic]
+#[should_panic(expected = "must be called after start_element()")]
 fn write_text_03() {
-    let mut w = XmlWriter::new(Options::default());
-    w.start_element("p");
-    w.end_element();
-    w.write_text("text"); // Should be called after start_element()
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("p").expect("should not fail");
+    w.end_element().expect("should not fail");
+    w.write_text("text")
+        .expect("should panic before giving us a Result"); // Should be called after start_element()
 }
 
 #[test]
-fn write_text_04() {
-    let mut w = XmlWriter::new(Options::default());
-    w.start_element("p");
-    w.write_text("text");
-    w.write_text("text");
-    text_eq!(w.end_document(),
-"<p>
+fn write_text_04() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("p")?;
+    w.write_text("text")?;
+    w.write_text("text")?;
+    text_eq!(
+        w.end_document()?,
+        r#"<p>
     text
     text
 </p>
-");
+"#
+    );
+    Ok(())
 }
 
 #[test]
-fn write_text_05() {
-    let mut w = XmlWriter::new(Options::default());
-    w.start_element("p");
-    w.write_text("text");
-    text_eq!(w.end_document(),
-"<p>
+fn write_text_05() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("p")?;
+    w.write_text("text")?;
+    text_eq!(
+        w.end_document()?,
+        r#"<p>
     text
 </p>
-");
+"#
+    );
+    Ok(())
 }
 
 #[test]
-fn write_text_06() {
-    let mut w = XmlWriter::new(Options::default());
-    w.start_element("p");
-    w.write_text("text");
-    w.start_element("p");
-    w.write_text("text");
-    text_eq!(w.end_document(),
-"<p>
+fn write_text_06() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("p")?;
+    w.write_text("text")?;
+    w.start_element("p")?;
+    w.write_text("text")?;
+    text_eq!(
+        w.end_document()?,
+        r#"<p>
     text
     <p>
         text
     </p>
 </p>
-");
+"#
+    );
+    Ok(())
 }
 
 #[test]
-fn write_text_07() {
-    let mut w = XmlWriter::new(Options::default());
-    w.start_element("div");
-    w.start_element("p");
-    w.write_text("text");
-    w.start_element("p");
-    w.write_text("text");
-    text_eq!(w.end_document(),
-"<div>
+fn write_text_07() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("div")?;
+    w.start_element("p")?;
+    w.write_text("text")?;
+    w.start_element("p")?;
+    w.write_text("text")?;
+    text_eq!(
+        w.end_document()?,
+        r#"<div>
     <p>
         text
         <p>
@@ -396,113 +501,171 @@ fn write_text_07() {
         </p>
     </p>
 </div>
-");
+"#
+    );
+    Ok(())
 }
 
 #[test]
-fn write_text_08() {
-    let mut w = XmlWriter::new(Options::default());
-    w.start_element("p");
-    w.write_text("<");
-    text_eq!(w.end_document(),
-"<p>
+fn write_text_08() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("p")?;
+    w.write_text("<")?;
+    text_eq!(
+        w.end_document()?,
+        r#"<p>
     &lt;
 </p>
-");
+"#
+    );
+    Ok(())
 }
 
 #[test]
-fn write_text_09() {
-    let mut w = XmlWriter::new(Options::default());
-    w.start_element("p");
-    w.write_text("<&>");
-    text_eq!(w.end_document(),
-"<p>
-    &lt;&>
+fn write_text_09() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("p")?;
+    w.write_text("<&>")?;
+    text_eq!(
+        w.end_document()?,
+        r#"<p>
+    &lt;&amp;&gt;
 </p>
-");
+"#
+    );
+    Ok(())
 }
 
 #[test]
-fn write_text_10() {
-    let mut w = XmlWriter::new(Options::default());
-    w.start_element("p");
-    w.write_text("&lt;");
-    text_eq!(w.end_document(),
-"<p>
-    &lt;
+fn write_text_10() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("p")?;
+    w.write_text("&lt;")?;
+    text_eq!(
+        w.end_document()?,
+        r#"<p>
+    &amp;lt;
 </p>
-");
+"#
+    );
+    Ok(())
 }
 
 #[test]
-fn write_text_11() {
-    let mut w = XmlWriter::new(Options::default());
-    w.start_element("p");
-    w.write_text("text");
-    w.start_element("p");
-    w.end_element();
-    w.write_text("text");
-    text_eq!(w.end_document(),
-"<p>
+fn write_text_11() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("p")?;
+    w.write_text("text")?;
+    w.start_element("p")?;
+    w.end_element()?;
+    w.write_text("text")?;
+    text_eq!(
+        w.end_document()?,
+        r#"<p>
     text
     <p/>
     text
 </p>
-");
+"#
+    );
+    Ok(())
 }
 
 #[test]
-fn write_preserve_text_01() {
-    let mut w = XmlWriter::new(Options::default());
-    w.set_preserve_whitespaces(true);
-    w.start_element("p");
-    w.write_text("text");
-    w.start_element("p");
-    w.end_element();
-    w.write_text("text");
-    text_eq!(w.end_document(),
-"<p>text<p/>text</p>");
+fn write_text_12() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("p")?;
+    w.write_attribute("att", "fooo&bar&&&&amp;&amp;&baz&&&")?;
+    w.write_text("fooo&bar&&&&amp;&amp;&baz&&&")?;
+    text_eq!(
+        w.end_document()?,
+        r#"<p att="fooo&amp;bar&amp;&amp;&amp;&amp;amp;&amp;amp;&amp;baz&amp;&amp;&amp;">
+    fooo&amp;bar&amp;&amp;&amp;&amp;amp;&amp;amp;&amp;baz&amp;&amp;&amp;
+</p>
+"#
+    );
+    Ok(())
 }
 
 #[test]
-fn write_preserve_text_02() {
-    let mut w = XmlWriter::new(Options::default());
-    w.start_element("p");
-    w.start_element("p");
+fn write_preserve_text_01() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
     w.set_preserve_whitespaces(true);
-    w.write_text("text");
-    w.start_element("p");
-    w.end_element();
-    w.write_text("text");
-    w.end_element();
+    w.start_element("p")?;
+    w.write_text("text")?;
+    w.start_element("p")?;
+    w.end_element()?;
+    w.write_text("text")?;
+    text_eq!(w.end_document()?, "<p>text<p/>text</p>");
+    Ok(())
+}
+
+#[test]
+fn write_preserve_text_02() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("p")?;
+    w.start_element("p")?;
+    w.set_preserve_whitespaces(true);
+    w.write_text("text")?;
+    w.start_element("p")?;
+    w.end_element()?;
+    w.write_text("text")?;
+    w.end_element()?;
     w.set_preserve_whitespaces(false);
-    text_eq!(w.end_document(),
-"<p>
+    text_eq!(
+        w.end_document()?,
+        r#"<p>
     <p>text<p/>text</p>
 </p>
-");
+"#
+    );
+    Ok(())
 }
 
 #[test]
-fn attrs_indent_01() {
+fn attrs_indent_01() -> io::Result<()> {
     let opt = Options {
         attributes_indent: xmlwriter::Indent::Spaces(2),
-        .. Options::default()
+        ..Options::default()
     };
 
-    let mut w = XmlWriter::new(opt);
-    w.start_element("rect");
-    w.write_attribute("x", "5");
-    w.start_element("rect");
-    w.write_attribute("x", "10");
-    w.write_attribute("y", "15");
-    text_eq!(w.end_document(),
-"<rect
-  x=\"5\">
+    let mut w = XmlWriter::new(Vec::<u8>::new(), opt);
+    w.start_element("rect")?;
+    w.write_attribute("x", "5")?;
+    w.start_element("rect")?;
+    w.write_attribute("x", "10")?;
+    w.write_attribute("y", "15")?;
+    text_eq!(
+        w.end_document()?,
+        r#"<rect
+  x="5">
     <rect
-      x=\"10\"
-      y=\"15\"/>
+      x="10"
+      y="15"/>
 </rect>
-");
+"#
+    );
+    Ok(())
+}
+
+// At some point I had used split_at() with a byte index but that does not work for multi-bytes
+// characters, so let's that to make sure it isn't reintroduced.
+#[test]
+fn multibytes_escaping() -> io::Result<()> {
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("test")?;
+    w.write_attribute("foo", "aaa&bbb<ccc•&•>&•")?;
+    w.write_attribute_fmt("bar", format_args!("aaa&bbb<ccc{}&•>&•", '•'))?;
+    w.write_text("aaa&bbb<ccc•&•>&•")?;
+    w.write_text_fmt(format_args!("aaa&bbb<ccc{}&•>&•", '•'))?;
+
+    text_eq!(
+        w.end_document()?,
+        r#"<test foo="aaa&amp;bbb&lt;ccc•&amp;•&gt;&amp;•" bar="aaa&amp;bbb&lt;ccc•&amp;•&gt;&amp;•">
+    aaa&amp;bbb&lt;ccc•&amp;•&gt;&amp;•
+    aaa&amp;bbb&lt;ccc•&amp;•&gt;&amp;•
+</test>
+"#
+    );
+    Ok(())
 }


### PR DESCRIPTION
_The commit message is copied underneath. For the "real" part of my explanations, see below_

This change is two-fold: it's now really a "streaming" XML writer, allowing to
pipe io::Write together for example to pipe it through a zip compressor, and
there's no need to make sure to escape all characters beforehand, as now all
characters that need escaping in a particular case (attributes, text, comments)
are handled entirely. Note that there was some level of escaping support, but it
was incomplete.

Amongst other things, here are some notable changes:
- xmlwriter is now really zero-copy, since previously it copied the element's name
  to handle closing tag auto-closing, in DepthData, but now we use a string slice
  with a lifetime ensuring we have it all along. Adding a lifetime should not be
  an issue at all since the vast majority of the time when you're writing some
  XML, you know what you're writing (there's a spec and all that), so the element
  name you're passing is very much likely just a 'static string literal anyway.
- used cargo fmt on the whole project
- removed duplicated README crate docs from the top of lib.rs to just including
  the root one directly with rustdoc
- a few negligible optimizations here and there
- removed unused TStr struct in tests and a duplicated test
- reviewed the whole code and changed a few minor things in some places
- expanded the test suite exhaustively to cover added escaped characters, and
  made sure the #[should_panic] are precise by setting the "expected" panic
  message.
  
---------

Hi, I made those changes as I'm working on some library that parses an XML file format using roxmltree, and needed some   nice way of writing back the XML once edited in the UI. I found your crate xmlwriter which suits me enough for the job, except that I needed to zip the written XML so it's nicer to have a io::Write implementation that can be piped between the zip compressor and xmlwriter, so I worked on that. I also noticed that escaping wasn't done at all for > and & in text and attributes, which is really necessary once I start exposing an UI to the file format, so I added support for those too in the fmt::Write write_str() implementation. The previous implementation overwrote after the fact all the characters that needed escaping, which obviously isn't possible and even something I'd want for a fully streaming XML writer.

Now, those changes were mostly done for my own use, but I believe changes done to free software should be sent back to their developers, if they make sense upstream, so I'm sending those here. I don't plan on publishing a fork of this crate or whatsoever, even if my changes aren't wanted here upstream. What could be most controversial is, I believe, that all functions return io::Result<()> now and it's no longer a turn-key solution where you get a String directly at the end, but it's still very nice to use in particular if passing a BufWriter<File> as the io::Write implementation and using `?` for the error handling. Obviously this MR also breaks API everywhere, so with regards to stability it's up to you to decide what to do about it.

Thanks for reading all this anyway :)

Fixes #1