### PR TITLE
Fixup merging of CDATA handling with io::Write/buffer rework

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -589,14 +589,17 @@ fn write_text_12() -> io::Result<()> {
 
 #[test]
 fn write_text_cdata() -> io::Result<()> {
-    let mut w = XmlWriter::new(Options::default());
-    w.start_element("script");
-    w.write_cdata_text("function cmp(a,b) { return (a<b)?-1:(a>b)?1:0; }");
-    text_eq!(w.end_document(),
-"<script><![CDATA[
+    let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
+    w.start_element("script")?;
+    w.write_cdata_text("function cmp(a,b) { return (a<b)?-1:(a>b)?1:0; }")?;
+    text_eq!(
+        w.end_document()?,
+        "<script><![CDATA[
     function cmp(a,b) { return (a<b)?-1:(a>b)?1:0; }
 ]]></script>
-");
+"
+    );
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
The merger of the master branch (w/ the write_cdata_text() was not done
properly so the code does not compile anymore. This commit fixes things
to bring back the write_cdata_text() code (part of which was gone) while
moving from internal buffer writes to io::Write methods.

This commit also drops Clone and Debug (effectively reverting
9912b2ac79b58e8b1b28db092d0e515eebb19ab0) as I can't make it actually
work in tests to output to the same buffer/io::Write, as it clones the
underlying writer too. In any case, I don't see the point in having
Clone to write part of the XML in a different manner, as the only thing
that's public in that matter is preserve_whitespaces, which can just be
set to false/true around the code that you want to write differently,
rather than cloning the XmlWriter.

-------------------------------

@Cactice: About Clone for XmlWriter (#3), I don't understand why you actually need to clone the XmlWriter to change the way the XML is written. The only setting available for you to change is preserve_whitespaces, but you can just use
```
xml.set_preserve_whitespaces(false);
// do your stuff here
xml.set_preserve_whitespaces(true);
```
The Options can't be changed after creation (or clone, in that case), so I can't see why you need to clone it after all. In any case, I did try keeping Clone support, but it did not lead to the appropriate behavior (i.e. the original and cloned XmlWriters are not writing to the same io::Write implementation). See the attached diff if you want to try it out yourself locally: 
[clone_preserve_whitespaces_xmlwriter.txt](https://github.com/RazrFalcon/xmlwriter/files/9446421/clone_preserve_whitespaces_xmlwriter.txt)