### PR TITLE
Add option for disabling self-closing tags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ pub struct Options {
     /// Default: `None`
     pub attributes_indent: Indent,
 
-    /// Write self-closing tags when element is empty
+    /// Write self-closing tags when element is empty.
     ///
     /// # Examples
     ///
@@ -146,10 +146,11 @@ pub struct Options {
     /// After:
     ///
     /// ```text
-    /// <tag></tag>
+    /// <tag>
+    /// </tag>
     /// ```
     ///
-    /// Default: Enabled
+    /// Default: enabled
     pub enable_self_closing: bool,
 }
 
@@ -658,6 +659,11 @@ impl<'a, W: Write> XmlWriter<'a, W> {
     pub fn end_element(&mut self) -> io::Result<()> {
         if let Some(depth) = self.depth_stack.pop() {
             if depth.has_children || !self.opt.enable_self_closing {
+                // Close the empty node here as there were no children to close it.
+                if !depth.has_children && !self.opt.enable_self_closing {
+                    self.fmt_writer.writer.write_all(b">")?;
+                }
+
                 if !self.preserve_whitespaces {
                     self.write_new_line()?;
                     self.write_node_indent()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,25 @@ pub struct Options {
     ///
     /// Default: `None`
     pub attributes_indent: Indent,
+
+    /// Write self-closing tags when element is empty
+    ///
+    /// # Examples
+    ///
+    /// Before:
+    ///
+    /// ```text
+    /// <tag/>
+    /// ```
+    ///
+    /// After:
+    ///
+    /// ```text
+    /// <tag></tag>
+    /// ```
+    ///
+    /// Default: Enabled
+    pub enable_self_closing: bool,
 }
 
 impl Default for Options {
@@ -141,6 +160,7 @@ impl Default for Options {
             use_single_quote: false,
             indent: Indent::Spaces(4),
             attributes_indent: Indent::None,
+            enable_self_closing: true,
         }
     }
 }
@@ -206,7 +226,7 @@ impl<W: Write> FmtWriter<W> {
             if let Some(escaped_char) = escaped_char {
                 // We have a character to escape, so write the previous part and the escaped character
                 self.writer
-                    .write_all(&s[part_start_pos..byte_pos].as_bytes())?;
+                    .write_all(s[part_start_pos..byte_pos].as_bytes())?;
                 self.writer.write_all(escaped_char)?;
                 // +1 skips the escaped character from part, for afterwards
                 part_start_pos = byte_pos + 1;
@@ -216,7 +236,7 @@ impl<W: Write> FmtWriter<W> {
             // just write out the rest of the string.
         }
         // Write the rest of the string which needs no escaping
-        self.writer.write_all(&s[part_start_pos..].as_bytes())
+        self.writer.write_all(s[part_start_pos..].as_bytes())
     }
 }
 
@@ -637,7 +657,7 @@ impl<'a, W: Write> XmlWriter<'a, W> {
     #[inline(never)]
     pub fn end_element(&mut self) -> io::Result<()> {
         if let Some(depth) = self.depth_stack.pop() {
-            if depth.has_children {
+            if depth.has_children || !self.opt.enable_self_closing {
                 if !self.preserve_whitespaces {
                     self.write_new_line()?;
                     self.write_node_indent()?;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -592,11 +592,13 @@ fn write_text_cdata() -> io::Result<()> {
     let mut w = XmlWriter::new(Vec::<u8>::new(), Options::default());
     w.start_element("script")?;
     w.write_cdata_text("function cmp(a,b) { return (a<b)?-1:(a>b)?1:0; }")?;
-    text_eq!(w.end_document()?,
-"<script><![CDATA[
+    text_eq!(
+        w.end_document()?,
+        "<script><![CDATA[
     function cmp(a,b) { return (a<b)?-1:(a>b)?1:0; }
 ]]></script>
-");
+"
+    );
     Ok(())
 }
 
@@ -680,5 +682,33 @@ fn multibytes_escaping() -> io::Result<()> {
 </test>
 "#
     );
+    Ok(())
+}
+
+#[test]
+fn disabled_self_close() -> io::Result<()> {
+    let opts = Options {
+        enable_self_closing: false,
+        ..Options::default()
+    };
+    let mut w = XmlWriter::new(Vec::<u8>::new(), opts);
+    w.start_element("empty1")?;
+    w.end_element()?;
+    w.start_element("wrapper")?;
+    w.start_element("empty2")?;
+    w.end_element()?;
+    w.end_element()?;
+
+    text_eq!(
+        w.end_document()?,
+        r#"<empty1>
+</empty1>
+<wrapper>
+    <empty2>
+    </empty2>
+</wrapper>
+"#
+    );
+
     Ok(())
 }


### PR DESCRIPTION
* Add option for disabling self-closing tags
* cargo clippy --fix

Title is pretty self-explanatory. While using the library I needed to generate empty elements with non-self-closing tags, so I added the option.